### PR TITLE
slf4j to 1.7.26-stable (CVE-2018-8088)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
+            <version>1.8.0-beta2</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.8.0-beta2</version>
+            <version>1.7.26</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
slf4j to 1.7.26-stable (CVE-2018-8088)
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-8088