### PR TITLE
Fix format of ephemeral username

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -49,6 +49,7 @@ External Service Discovery Plugin Changelog
     <li>Added Ukrainian (uk_UA) created and provided by Yurii Savchuk (svais) and his son Vladislav Savchuk (Bruhmozavr)!</a>
     <li>Added French translation created and provided by Fred Eric (Pastis67)!</li>
     <li>Added Portuguese translations, provided by Miguel Veiga</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-externalservicediscovery-plugin/issues/13'>#13</a>] - Fix format of ephemeral username.</li>
     <li>[<a href='https://issues.igniterealtime.org/browse/OF-1517'>OF-1517</a>] - Don't require i18n source files for all plugins to be encoded.</li>
     <li>[<a href='https://issues.igniterealtime.org/browse/OF-1641'>OF-1641</a>] - Ensure all JSP pages have the correct contentType.</li>
     <li>Minimum Java requirement: 1.8</li>

--- a/changelog.html
+++ b/changelog.html
@@ -52,6 +52,7 @@ External Service Discovery Plugin Changelog
     <li>[<a href='https://github.com/igniterealtime/openfire-externalservicediscovery-plugin/issues/13'>#13</a>] - Fix format of ephemeral username.</li>
     <li>[<a href='https://issues.igniterealtime.org/browse/OF-1517'>OF-1517</a>] - Don't require i18n source files for all plugins to be encoded.</li>
     <li>[<a href='https://issues.igniterealtime.org/browse/OF-1641'>OF-1641</a>] - Ensure all JSP pages have the correct contentType.</li>
+    <li>Update nl.jqno.equalsverifier:equalsverifier to release 3.15.3</li>
     <li>Minimum Java requirement: 1.8</li>
 </ul>
 

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
-            <version>3.1.8</version>
+            <version>3.15.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/java/org/igniterealtime/openfire/plugins/externalservicediscovery/Service.java
+++ b/src/java/org/igniterealtime/openfire/plugins/externalservicediscovery/Service.java
@@ -312,7 +312,7 @@ public final class Service
                 {
                     // Although RFC 5389 appears to allow for unescaped JIDs to be used as TURN usernames, problems have
                     // been reported (eg: https://github.com/versatica/JsSIP/issues/184)111
-                    username = URLEncoder.encode( user.toBareJID(), "ASCII" ) + ":" + asSecondsSinceEpoch;
+                    username = asSecondsSinceEpoch + ":" + URLEncoder.encode( user.toBareJID(), "ASCII" );
                 }
                 catch ( UnsupportedEncodingException e )
                 {


### PR DESCRIPTION
As per the [REST API for Access to TURN Services][1], emit usernames of the form `$timestamp:$jid` rather than `$jid:$timestamp`.

[1]: https://datatracker.ietf.org/doc/html/draft-uberti-behave-turn-rest-00