### PR TITLE
fix #22: Compatibility with Openfire 5.0.0

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -45,6 +45,7 @@ External Service Discovery Plugin Changelog
 
 <p><b>1.0.4</b> -- (To be determined)</p>
 <ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-externalservicediscovery-plugin/issues/22'>#22</a>] - Compatible with Openfire 5.0.0</li>
 </ul>
 
 <p><b>1.0.3</b> -- September 12, 2024</p>

--- a/plugin.xml
+++ b/plugin.xml
@@ -5,7 +5,7 @@
     <description>Allows XMPP entities to discover services external to the XMPP network, such as STUN and TURN servers.</description>
     <author>Guus der Kinderen</author>
     <version>${project.version}</version>
-    <date>2024-09-12</date>
+    <date>2025-06-12</date>
     <minServerVersion>4.2.0</minServerVersion>
     <minJavaVersion>1.8</minJavaVersion>
 

--- a/src/java/org/igniterealtime/openfire/plugins/externalservicediscovery/Service.java
+++ b/src/java/org/igniterealtime/openfire/plugins/externalservicediscovery/Service.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package org.igniterealtime.openfire.plugins.externalservicediscovery;
 
 import org.jivesoftware.database.JiveID;
 import org.jivesoftware.database.SequenceManager;
-import org.jivesoftware.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmpp.packet.JID;
@@ -29,6 +28,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
 import java.util.Date;
 
 /**
@@ -327,7 +327,7 @@ public final class Service
                 final Mac mac = Mac.getInstance( "HmacSHA1" );
                 mac.init( secretKey );
                 final byte[] nonce = mac.doFinal( username.getBytes( StandardCharsets.UTF_8 ) );
-                password = StringUtils.encodeBase64( nonce );
+                password = Base64.getEncoder().encodeToString( nonce );
             }
             catch ( InvalidKeyException | NoSuchAlgorithmException e )
             {


### PR DESCRIPTION
This replaces a custom implementation for Base64 encoding with one provided by Java.

In Openfire 5.0.0, the custom implementation is removed. With this change, the plugin is compatible with Openfire 5.0.0 (but also earlier versions).